### PR TITLE
Changed data type of `permissions` from List<String> to ArrayList<String>

### DIFF
--- a/betterpermission/src/main/java/com/github/edwnmrtnz/betterpermission/BetterPermission.java
+++ b/betterpermission/src/main/java/com/github/edwnmrtnz/betterpermission/BetterPermission.java
@@ -21,7 +21,7 @@ public class BetterPermission {
 
     private Context context;
 
-    private List<String> permissions;
+    private ArrayList<String> permissions;
 
     private PermissionCallback permissionCallback;
 
@@ -32,7 +32,7 @@ public class BetterPermission {
     }
 
     public BetterPermission setPermissions(String...permissions){
-        this.permissions = Arrays.asList(permissions);
+        this.permissions = new ArrayList<>(Arrays.asList(permissions));
         return this;
     }
 


### PR DESCRIPTION
* Causes `Caused by: java.lang.UnsupportedOperationException` every time `permissions.clear()` is called.